### PR TITLE
Bugfix with print

### DIFF
--- a/jeezus
+++ b/jeezus
@@ -140,7 +140,7 @@ def handle(to, sender, subject, body):
 
 def main(args=args):
     args = format_args(args)
-    print args
+    print(args)
     inbox.serve(address=args.listenhost, port=args.listenport)
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed error "Missing parentheses in call to 'print'" when calling jeezus without any arguments